### PR TITLE
apply clickableProps to render

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -223,7 +223,7 @@ const Toast = ({
       } ${isExit ? 'toast-exit-active' : ''} ${className}`}
     >
       {render ? (
-        render(message)
+        <div {...(clickable && clickableProps)}>{render(message)}</div>
       ) : (
         <div className={contentClassNames} {...(clickable && clickableProps)}>
           {message}


### PR DESCRIPTION
## 🌁 배경
render 옵션을 사용하면 clickClosable 옵션이 적용 되지 않음.


## 👩‍💻 작업 내용 (Content)
Toast 컴포넌트에서 render(message) 결과를 div로 감싸고, 관련된 props를 전달해줌.

