### PR TITLE
DeleteSliceMethod

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -328,10 +328,6 @@ function renderToast(
   if (reverse) toastComponentList.unshift(newToastComponent);
   else toastComponentList.push(newToastComponent);
 
-  const visibleToastOffset =
-    maxVisibleToasts && toastComponentList.length - maxVisibleToasts;
-  if (visibleToastOffset) toastComponentList.slice(visibleToastOffset);
-
   if (maxVisibleToasts) {
     const toastsToRemove = toastComponentList.length - maxVisibleToasts;
     for (let i = 0; i < toastsToRemove; i++) {


### PR DESCRIPTION
## 🌁 배경
- 출력 콘솔을 찍어본 결과, slice 함수의 용도가 필요 없다고 판단

## 👩‍💻 작업 내용 (Content)
- visubleToastOffset 부분을 삭제하였습니다.

## 📱 스크린샷
<p align="left">
  <img width="800" alt="스크린샷1" src="https://github.com/Kim-Yeon-ho/react-simple-toasts/assets/93366605/7c1c785d-6a4c-499a-beb8-1848f0de22ca">
</p>
